### PR TITLE
feat: scaffold task board framework

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,9 @@
+import TaskBoard from "@/components/task-board";
+
 export default function Home() {
   return (
     <section className="flex flex-1 flex-col gap-4 p-4 w-full h-full">
-      <div className="grid auto-rows-min gap-4 md:grid-cols-3">
-        <div className="bg-muted/50 aspect-video rounded-xl" />
-        <div className="bg-muted/50 aspect-video rounded-xl" />
-        <div className="bg-muted/50 aspect-video rounded-xl" />
-      </div>
-      <div className="bg-muted/50 min-h-[100vh] w-full flex-1 rounded-xl md:min-h-min" />
+      <TaskBoard />
     </section>
   );
 }

--- a/src/components/task-board.tsx
+++ b/src/components/task-board.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import useTaskStore from "@/lib/stores/task-store";
+
+import type { Project } from "@/lib/types/todo";
+
+const TaskBoard = () => {
+  const { projects, tasks } = useTaskStore();
+
+  return (
+    <div className="flex gap-4">
+      {projects.map((project: Project) => (
+        <div
+          key={project.id}
+          className="bg-muted/50 rounded-xl p-4 w-60 min-h-60"
+        >
+          <h2 className="mb-2 font-semibold">{project.title}</h2>
+          {project.taskIds.map((taskId: string) => {
+            const task = tasks[taskId];
+            return (
+              <div
+                key={taskId}
+                className="bg-background rounded p-2 mb-2 shadow"
+              >
+                {task.title}
+              </div>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default TaskBoard;

--- a/src/lib/stores/task-store.ts
+++ b/src/lib/stores/task-store.ts
@@ -1,0 +1,55 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+
+import type { Project, Task } from "@/lib/types/todo";
+
+type TaskState = {
+  projects: Project[];
+  tasks: Record<string, Task>;
+  moveTask: (taskId: string, targetProjectId: string) => void;
+};
+
+export const useTaskStore = create<TaskState>()(
+  devtools((set) => ({
+    projects: [
+      { id: "project-1", title: "Todo", taskIds: ["task-1", "task-2"] },
+      { id: "project-2", title: "In Progress", taskIds: [] },
+      { id: "project-3", title: "Done", taskIds: [] },
+    ],
+    tasks: {
+      "task-1": { id: "task-1", title: "Set up project", projectId: "project-1" },
+      "task-2": { id: "task-2", title: "Add drag-and-drop", projectId: "project-1" },
+    },
+    moveTask: (taskId, targetProjectId) =>
+      set((state) => {
+        const task = state.tasks[taskId];
+        if (!task) return state;
+
+        const sourceProjectId = task.projectId;
+        if (sourceProjectId === targetProjectId) return state;
+
+        const updatedProjects = state.projects.map((project) => {
+          if (project.id === sourceProjectId) {
+            return {
+              ...project,
+              taskIds: project.taskIds.filter((id) => id !== taskId),
+            };
+          }
+          if (project.id === targetProjectId) {
+            return { ...project, taskIds: [...project.taskIds, taskId] };
+          }
+          return project;
+        });
+
+        return {
+          projects: updatedProjects,
+          tasks: {
+            ...state.tasks,
+            [taskId]: { ...task, projectId: targetProjectId },
+          },
+        };
+      }, false, "moveTask"),
+  }))
+);
+
+export default useTaskStore;

--- a/src/lib/types/todo.ts
+++ b/src/lib/types/todo.ts
@@ -1,0 +1,11 @@
+export interface Task {
+  id: string;
+  title: string;
+  projectId: string;
+}
+
+export interface Project {
+  id: string;
+  title: string;
+  taskIds: string[];
+}


### PR DESCRIPTION
## Summary
- add basic types for tasks and projects
- introduce Zustand store for task management
- render a simple task board on the home page

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_689896495998832a829a593c6cb34535