### PR TITLE
Use Web Crypto for JWT signing to support edge runtime

### DIFF
--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -14,7 +14,7 @@ export default async function UsersPage() {
   if (!token) redirect("/login");
   let currentUser;
   try {
-    currentUser = verifyToken(token);
+    currentUser = await verifyToken(token);
   } catch {
     redirect("/login");
   }
@@ -25,7 +25,7 @@ export default async function UsersPage() {
     const cookieStore = await cookies();
     const token = cookieStore.get("auth")?.value;
     if (!token) return;
-    const user = verifyToken(token);
+    const user = await verifyToken(token);
     if (user.role !== "admin") return;
     const email = formData.get("email") as string;
     const password = formData.get("password") as string;

--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -11,7 +11,7 @@ export async function POST(req: NextRequest) {
   if (!user || !(await bcrypt.compare(password, user.hashed_password))) {
     return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
   }
-  const token = signToken({ id: user.id, role: user.role });
+  const token = await signToken({ id: user.id, role: user.role });
   const res = NextResponse.json({ ok: true });
   res.cookies.set("auth", token, { httpOnly: true, path: "/" });
   return res;

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -6,18 +6,18 @@ import bcrypt from "bcryptjs";
 import prisma from "@/lib/prisma";
 import { verifyToken } from "@/lib/server/auth";
 
-function getAuthUser(req: NextRequest) {
+async function getAuthUser(req: NextRequest) {
   const token = req.cookies.get("auth")?.value;
   if (!token) return null;
   try {
-    return verifyToken(token);
+    return await verifyToken(token);
   } catch {
     return null;
   }
 }
 
 export async function GET(req: NextRequest) {
-  const user = getAuthUser(req);
+  const user = await getAuthUser(req);
   if (!user || user.role !== "admin") {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -26,7 +26,7 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  const user = getAuthUser(req);
+  const user = await getAuthUser(req);
   if (!user || user.role !== "admin") {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -1,35 +1,71 @@
-import crypto from "crypto";
-
 import type { Role } from "@prisma/client";
 
 const SECRET = process.env.AUTH_SECRET || "dev-secret";
 
-function base64url(input: Buffer) {
-  return input
-    .toString("base64")
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function base64url(input: Uint8Array) {
+  return btoa(String.fromCharCode(...input))
     .replace(/=/g, "")
     .replace(/\+/g, "-")
     .replace(/\//g, "_");
 }
 
-export function signToken(payload: { id: string; role: Role }) {
-  const header = base64url(Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })));
-  const body = base64url(Buffer.from(JSON.stringify(payload)));
+function base64urlDecode(str: string) {
+  str = str.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = str.length % 4;
+  if (pad) str += "=".repeat(4 - pad);
+  const binary = atob(str);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+const keyPromise = crypto.subtle.importKey(
+  "raw",
+  encoder.encode(SECRET),
+  { name: "HMAC", hash: "SHA-256" },
+  false,
+  ["sign", "verify"],
+);
+
+export async function signToken(payload: { id: string; role: Role }) {
+  const key = await keyPromise;
+  const header = base64url(
+    encoder.encode(JSON.stringify({ alg: "HS256", typ: "JWT" })),
+  );
+  const body = base64url(encoder.encode(JSON.stringify(payload)));
   const data = `${header}.${body}`;
-  const signature = base64url(crypto.createHmac("sha256", SECRET).update(data).digest());
+  const signatureBytes = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(data),
+  );
+  const signature = base64url(new Uint8Array(signatureBytes));
   return `${data}.${signature}`;
 }
 
-export function verifyToken(token: string): { id: string; role: Role } {
+export async function verifyToken(
+  token: string,
+): Promise<{ id: string; role: Role }> {
   const [headerB64, bodyB64, signature] = token.split(".");
   if (!headerB64 || !bodyB64 || !signature) {
     throw new Error("Invalid token");
   }
   const data = `${headerB64}.${bodyB64}`;
-  const expected = base64url(crypto.createHmac("sha256", SECRET).update(data).digest());
-  if (signature !== expected) {
+  const key = await keyPromise;
+  const valid = await crypto.subtle.verify(
+    "HMAC",
+    key,
+    base64urlDecode(signature),
+    encoder.encode(data),
+  );
+  if (!valid) {
     throw new Error("Invalid signature");
   }
-  const payload = JSON.parse(Buffer.from(bodyB64, "base64").toString());
+  const payload = JSON.parse(decoder.decode(base64urlDecode(bodyB64)));
   return payload;
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,7 +10,7 @@ function unauthorized(request: NextRequest) {
   return NextResponse.redirect(new URL("/login", request.url));
 }
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const headers = new Headers(request.headers);
   headers.set("x-current-path", pathname);
@@ -24,7 +24,7 @@ export function middleware(request: NextRequest) {
     return unauthorized(request);
   }
   try {
-    const user = verifyToken(token);
+    const user = await verifyToken(token);
     if (pathname.startsWith("/admin") || pathname.startsWith("/api/users")) {
       if (user.role !== "admin") {
         return unauthorized(request);


### PR DESCRIPTION
## Summary
- replace Node `crypto` with Web Crypto in JWT helper
- update login route, middleware, and user handlers for async token API

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run type-check` *(fails: Could not find a declaration file for module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_6899bdae1378832ab5b1875302c0eb32