### PR TITLE
feat: add project dashboard and task management

### DIFF
--- a/src/components/task-board.tsx
+++ b/src/components/task-board.tsx
@@ -1,33 +1,241 @@
 'use client';
 
-import useTaskStore from "@/lib/stores/task-store";
+import { useState } from 'react';
 
-import type { Project } from "@/lib/types/todo";
+import useTaskStore from '@/lib/stores/task-store';
+
+import type { Project, Task } from '@/lib/types/todo';
 
 const TaskBoard = () => {
-  const { projects, tasks } = useTaskStore();
+  const {
+    projects,
+    tasks,
+    addProject,
+    removeProject,
+    addTask,
+    removeTask,
+    moveTask,
+  } = useTaskStore();
+
+  const [projectTitle, setProjectTitle] = useState('');
+
+  const handleProjectSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!projectTitle.trim()) return;
+    addProject(projectTitle.trim());
+    setProjectTitle('');
+  };
 
   return (
-    <div className="flex gap-4">
-      {projects.map((project: Project) => (
-        <div
-          key={project.id}
-          className="bg-muted/50 rounded-xl p-4 w-60 min-h-60"
+    <div className="flex flex-col gap-4">
+      <form onSubmit={handleProjectSubmit} className="flex gap-2">
+        <input
+          value={projectTitle}
+          onChange={(e) => setProjectTitle(e.target.value)}
+          placeholder="New project title"
+          className="flex-1 rounded border px-2 py-1"
+        />
+        <button
+          type="submit"
+          className="rounded bg-primary px-2 py-1 text-primary-foreground"
         >
-          <h2 className="mb-2 font-semibold">{project.title}</h2>
-          {project.taskIds.map((taskId: string) => {
-            const task = tasks[taskId];
-            return (
-              <div
-                key={taskId}
-                className="bg-background rounded p-2 mb-2 shadow"
-              >
-                {task.title}
-              </div>
-            );
-          })}
+          Add
+        </button>
+      </form>
+      <div className="flex gap-4 overflow-x-auto">
+        {projects.map((project) => (
+          <ProjectColumn
+            key={project.id}
+            project={project}
+            tasks={tasks}
+            addTask={addTask}
+            removeTask={removeTask}
+            removeProject={removeProject}
+            moveTask={moveTask}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+interface ColumnProps {
+  project: Project;
+  tasks: Record<string, Task>;
+  addTask: (
+    projectId: string,
+    input: Omit<Task, "id" | "projectId">
+  ) => void;
+  removeTask: (taskId: string) => void;
+  removeProject: (id: string) => void;
+  moveTask: (taskId: string, targetProjectId: string) => void;
+}
+
+const ProjectColumn = ({
+  project,
+  tasks,
+  addTask,
+  removeTask,
+  removeProject,
+  moveTask,
+}: ColumnProps) => {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [priority, setPriority] = useState<'low' | 'medium' | 'high'>('medium');
+  const [criticality, setCriticality] = useState<'normal' | 'critical'>('normal');
+  const [deadline, setDeadline] = useState('');
+
+  const projectTasks = project.taskIds
+    .map((id) => tasks[id])
+    .filter((t): t is Task => Boolean(t));
+  const nextDeadline = projectTasks
+    .filter((t) => t.deadline)
+    .sort(
+      (a, b) =>
+        new Date(a.deadline!).getTime() - new Date(b.deadline!).getTime()
+    )[0]?.deadline;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+    addTask(project.id, {
+      title,
+      description,
+      priority,
+      criticality,
+      deadline,
+    });
+    setTitle('');
+    setDescription('');
+    setPriority('medium');
+    setCriticality('normal');
+    setDeadline('');
+  };
+
+  const handleDragOver = (e: React.DragEvent) => e.preventDefault();
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    const taskId = e.dataTransfer.getData('text/plain');
+    moveTask(taskId, project.id);
+  };
+
+  return (
+    <div
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+      className="flex w-72 flex-col rounded-xl bg-muted/50 p-4"
+    >
+      <div className="mb-2 flex items-center justify-between">
+        <div>
+          <h2 className="font-semibold">{project.title}</h2>
+          <p className="text-xs text-muted-foreground">
+            {projectTasks.length} tasks
+            {nextDeadline
+              ? ` • next: ${new Date(nextDeadline).toLocaleDateString()}`
+              : ''}
+          </p>
         </div>
-      ))}
+        <button
+          onClick={() => removeProject(project.id)}
+          className="text-xs text-red-600"
+          aria-label="Delete project"
+        >
+          ✕
+        </button>
+      </div>
+      <div className="flex-1">
+        {projectTasks.map((task) => {
+          const deadlineDate = task.deadline ? new Date(task.deadline) : null;
+          let border = '';
+          if (deadlineDate) {
+            const now = new Date();
+            if (deadlineDate < now) border = 'border-red-500';
+            else if (
+              deadlineDate.getTime() - now.getTime() < 24 * 60 * 60 * 1000
+            )
+              border = 'border-yellow-500';
+          }
+          return (
+            <div
+              key={task.id}
+              draggable
+              onDragStart={(e) =>
+                e.dataTransfer.setData('text/plain', task.id)
+              }
+              className={`mb-2 rounded border bg-background p-2 shadow ${border}`}
+            >
+              <div className="flex items-center justify-between">
+                <span>{task.title}</span>
+                <button
+                  onClick={() => removeTask(task.id)}
+                  className="text-xs text-red-600"
+                  aria-label="Delete task"
+                >
+                  ✕
+                </button>
+              </div>
+              {task.deadline && (
+                <p className="text-xs text-muted-foreground">
+                  {new Date(task.deadline).toLocaleDateString()}
+                </p>
+              )}
+            </div>
+          );
+        })}
+      </div>
+      <form onSubmit={handleSubmit} className="mt-2 flex flex-col gap-1 text-sm">
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Task title"
+          className="rounded border px-2 py-1"
+        />
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Description"
+          className="rounded border px-2 py-1"
+        />
+        <div className="flex gap-1">
+          <select
+            value={priority}
+            onChange={(e) =>
+              setPriority(
+                e.target.value as 'low' | 'medium' | 'high'
+              )
+            }
+            className="flex-1 rounded border px-2 py-1"
+          >
+            <option value="low">Low</option>
+            <option value="medium">Medium</option>
+            <option value="high">High</option>
+          </select>
+          <select
+            value={criticality}
+            onChange={(e) =>
+              setCriticality(
+                e.target.value as 'normal' | 'critical'
+              )
+            }
+            className="flex-1 rounded border px-2 py-1"
+          >
+            <option value="normal">Normal</option>
+            <option value="critical">Critical</option>
+          </select>
+        </div>
+        <input
+          type="date"
+          value={deadline}
+          onChange={(e) => setDeadline(e.target.value)}
+          className="rounded border px-2 py-1"
+        />
+        <button
+          type="submit"
+          className="mt-1 rounded bg-primary px-2 py-1 text-primary-foreground"
+        >
+          Add Task
+        </button>
+      </form>
     </div>
   );
 };

--- a/src/lib/stores/task-store.ts
+++ b/src/lib/stores/task-store.ts
@@ -3,9 +3,22 @@ import { devtools } from "zustand/middleware";
 
 import type { Project, Task } from "@/lib/types/todo";
 
+interface TaskInput {
+  title: string;
+  description?: string;
+  priority: "low" | "medium" | "high";
+  criticality: "normal" | "critical";
+  deadline?: string;
+}
+
 type TaskState = {
   projects: Project[];
   tasks: Record<string, Task>;
+  addProject: (title: string) => void;
+  removeProject: (id: string) => void;
+  addTask: (projectId: string, input: TaskInput) => void;
+  updateTask: (taskId: string, input: Partial<Task>) => void;
+  removeTask: (taskId: string) => void;
   moveTask: (taskId: string, targetProjectId: string) => void;
 };
 
@@ -17,38 +30,127 @@ export const useTaskStore = create<TaskState>()(
       { id: "project-3", title: "Done", taskIds: [] },
     ],
     tasks: {
-      "task-1": { id: "task-1", title: "Set up project", projectId: "project-1" },
-      "task-2": { id: "task-2", title: "Add drag-and-drop", projectId: "project-1" },
+      "task-1": {
+        id: "task-1",
+        title: "Set up project",
+        description: "Initial repository setup",
+        priority: "medium",
+        criticality: "normal",
+        projectId: "project-1",
+      },
+      "task-2": {
+        id: "task-2",
+        title: "Add drag-and-drop",
+        description: "Allow moving tasks between columns",
+        priority: "high",
+        criticality: "critical",
+        projectId: "project-1",
+      },
     },
-    moveTask: (taskId, targetProjectId) =>
-      set((state) => {
-        const task = state.tasks[taskId];
-        if (!task) return state;
-
-        const sourceProjectId = task.projectId;
-        if (sourceProjectId === targetProjectId) return state;
-
-        const updatedProjects = state.projects.map((project) => {
-          if (project.id === sourceProjectId) {
-            return {
-              ...project,
-              taskIds: project.taskIds.filter((id) => id !== taskId),
-            };
-          }
-          if (project.id === targetProjectId) {
-            return { ...project, taskIds: [...project.taskIds, taskId] };
-          }
-          return project;
-        });
-
-        return {
-          projects: updatedProjects,
+    addProject: (title) =>
+      set(
+        (state) => ({
+          projects: [
+            ...state.projects,
+            { id: `project-${Date.now()}`, title, taskIds: [] },
+          ],
+        }),
+        false,
+        "addProject"
+      ),
+    removeProject: (id) =>
+      set(
+        (state) => {
+          const project = state.projects.find((p) => p.id === id);
+          const remainingTasks = { ...state.tasks };
+          project?.taskIds.forEach((taskId) => delete remainingTasks[taskId]);
+          return {
+            projects: state.projects.filter((p) => p.id !== id),
+            tasks: remainingTasks,
+          };
+        },
+        false,
+        "removeProject"
+      ),
+    addTask: (projectId, input) =>
+      set(
+        (state) => {
+          const id = `task-${Date.now()}`;
+          return {
+            tasks: {
+              ...state.tasks,
+              [id]: { id, projectId, ...input },
+            },
+            projects: state.projects.map((p) =>
+              p.id === projectId
+                ? { ...p, taskIds: [...p.taskIds, id] }
+                : p
+            ),
+          };
+        },
+        false,
+        "addTask"
+      ),
+    updateTask: (taskId, input) =>
+      set(
+        (state) => ({
           tasks: {
             ...state.tasks,
-            [taskId]: { ...task, projectId: targetProjectId },
+            [taskId]: { ...state.tasks[taskId], ...input },
           },
-        };
-      }, false, "moveTask"),
+        }),
+        false,
+        "updateTask"
+      ),
+    removeTask: (taskId) =>
+      set(
+        (state) => {
+          const newTasks = { ...state.tasks };
+          delete newTasks[taskId];
+          return {
+            tasks: newTasks,
+            projects: state.projects.map((p) => ({
+              ...p,
+              taskIds: p.taskIds.filter((id) => id !== taskId),
+            })),
+          };
+        },
+        false,
+        "removeTask"
+      ),
+    moveTask: (taskId, targetProjectId) =>
+      set(
+        (state) => {
+          const task = state.tasks[taskId];
+          if (!task) return state;
+
+          const sourceProjectId = task.projectId;
+          if (sourceProjectId === targetProjectId) return state;
+
+          const updatedProjects = state.projects.map((project) => {
+            if (project.id === sourceProjectId) {
+              return {
+                ...project,
+                taskIds: project.taskIds.filter((id) => id !== taskId),
+              };
+            }
+            if (project.id === targetProjectId) {
+              return { ...project, taskIds: [...project.taskIds, taskId] };
+            }
+            return project;
+          });
+
+          return {
+            projects: updatedProjects,
+            tasks: {
+              ...state.tasks,
+              [taskId]: { ...task, projectId: targetProjectId },
+            },
+          };
+        },
+        false,
+        "moveTask"
+      ),
   }))
 );
 

--- a/src/lib/types/todo.ts
+++ b/src/lib/types/todo.ts
@@ -1,6 +1,10 @@
 export interface Task {
   id: string;
   title: string;
+  description?: string;
+  priority: "low" | "medium" | "high";
+  criticality: "normal" | "critical";
+  deadline?: string;
   projectId: string;
 }
 

--- a/src/types/bcryptjs.d.ts
+++ b/src/types/bcryptjs.d.ts
@@ -1,0 +1,1 @@
+declare module 'bcryptjs';


### PR DESCRIPTION
## Summary
- expand task data with description, priority, criticality and deadlines
- add zustand store actions for project and task CRUD with moving between projects
- build interactive task board with project creation, task forms, drag-and-drop and deadline indicators

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6899c6abd460832abb641f486edfd3eb