### PR TITLE
Add admin management, user projects, and logout

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function AdminPage() {
+  redirect("/admin/users");
+}

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -12,7 +12,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
   }
   const token = await signToken({ id: user.id, role: user.role });
-  const res = NextResponse.json({ ok: true });
+  const res = NextResponse.json({ ok: true, role: user.role });
   res.cookies.set("auth", token, { httpOnly: true, path: "/" });
   return res;
 }

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -8,7 +8,7 @@ export async function GET(
   { params }: { params: { id: string } },
 ) {
   const user = await getAuthUser(req);
-  if (!user) {
+  if (!user || user.role !== "user") {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   const project = await prisma.project.findFirst({
@@ -26,7 +26,7 @@ export async function PUT(
   { params }: { params: { id: string } },
 ) {
   const user = await getAuthUser(req);
-  if (!user) {
+  if (!user || user.role !== "user") {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   const exists = await prisma.project.findFirst({
@@ -48,7 +48,7 @@ export async function DELETE(
   { params }: { params: { id: string } },
 ) {
   const user = await getAuthUser(req);
-  if (!user) {
+  if (!user || user.role !== "user") {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   const exists = await prisma.project.findFirst({

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -5,7 +5,7 @@ import { getAuthUser } from "@/lib/server/auth";
 
 export async function GET(req: NextRequest) {
   const user = await getAuthUser(req);
-  if (!user) {
+  if (!user || user.role !== "user") {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   const projects = await prisma.project.findMany({ where: { user_id: user.id } });
@@ -14,7 +14,7 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   const user = await getAuthUser(req);
-  if (!user) {
+  if (!user || user.role !== "user") {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   const data = await req.json();

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -8,7 +8,7 @@ export async function PUT(
   { params }: { params: { id: string } },
 ) {
   const user = await getAuthUser(req);
-  if (!user) {
+  if (!user || user.role !== "user") {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   const exists = await prisma.task.findFirst({
@@ -38,7 +38,7 @@ export async function DELETE(
   { params }: { params: { id: string } },
 ) {
   const user = await getAuthUser(req);
-  if (!user) {
+  if (!user || user.role !== "user") {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   const exists = await prisma.task.findFirst({

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -5,7 +5,7 @@ import { getAuthUser } from "@/lib/server/auth";
 
 export async function GET(req: NextRequest) {
   const user = await getAuthUser(req);
-  if (!user) {
+  if (!user || user.role !== "user") {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   const projectId = req.nextUrl.searchParams.get("projectId") || undefined;
@@ -17,7 +17,7 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   const user = await getAuthUser(req);
-  if (!user) {
+  if (!user || user.role !== "user") {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   const data = await req.json();

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -32,6 +32,8 @@ export async function DELETE(
   if (!auth || auth.role !== "admin") {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+  await prisma.task.deleteMany({ where: { user_id: params.id } });
+  await prisma.project.deleteMany({ where: { user_id: params.id } });
   await prisma.user.delete({ where: { id: params.id } });
   return NextResponse.json({ ok: true });
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,32 +1,71 @@
-"use client";
-
-import { useEffect, useState } from "react";
+/* eslint-disable import/order */
+import { revalidatePath } from "next/cache";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 
 import ProjectCard from "@/components/project-card";
+import prisma from "@/lib/prisma";
+import { verifyToken } from "@/lib/server/auth";
 
-interface Project {
-  id: string;
-  title: string;
-  description?: string | null;
-}
+export default async function DashboardPage() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("auth")?.value;
+  if (!token) redirect("/login");
+  let user;
+  try {
+    user = await verifyToken(token);
+  } catch {
+    redirect("/login");
+  }
+  if (user.role !== "user") redirect("/admin/users");
 
-export default function DashboardPage() {
-  const [projects, setProjects] = useState<Project[]>([]);
+  async function addProject(formData: FormData) {
+    "use server";
+    const cookieStore = await cookies();
+    const token = cookieStore.get("auth")?.value;
+    if (!token) return;
+    const user = await verifyToken(token);
+    if (user.role !== "user") return;
+    const title = formData.get("title") as string;
+    const description = (formData.get("description") as string) || null;
+    await prisma.project.create({
+      data: { title, description, user_id: user.id },
+    });
+    revalidatePath("/dashboard");
+  }
 
-  useEffect(() => {
-    fetch("/api/projects")
-      .then((res) => (res.ok ? res.json() : []))
-      .then((data) => setProjects(data));
-  }, []);
+  const projects = await prisma.project.findMany({
+    where: { user_id: user.id },
+  });
 
   return (
-    <section className="grid gap-4 p-4 md:grid-cols-3">
-      {projects.map((p) => (
-        <ProjectCard key={p.id} project={p} />
-      ))}
-      {projects.length === 0 && (
-        <p className="text-muted-foreground">No projects yet.</p>
-      )}
+    <section className="p-4">
+      <form action={addProject} className="mb-4 flex flex-col gap-2 max-w-md">
+        <input
+          className="border p-2"
+          name="title"
+          type="text"
+          placeholder="Project title"
+          required
+        />
+        <input
+          className="border p-2"
+          name="description"
+          type="text"
+          placeholder="Description"
+        />
+        <button className="bg-blue-500 text-white p-2" type="submit">
+          New Project
+        </button>
+      </form>
+      <div className="grid gap-4 md:grid-cols-3">
+        {projects.map((p) => (
+          <ProjectCard key={p.id} project={p} />
+        ))}
+        {projects.length === 0 && (
+          <p className="text-muted-foreground">No projects yet.</p>
+        )}
+      </div>
     </section>
   );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -19,7 +19,12 @@ export default function LoginPage() {
       credentials: "include",
     });
     if (res.ok) {
-      router.push("/");
+      const data = await res.json();
+      if (data.role === "admin") {
+        router.push("/admin/users");
+      } else {
+        router.push("/dashboard");
+      }
     } else {
       setError("Invalid credentials");
     }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,20 @@
+import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
-export default function Home() {
-  redirect("/dashboard");
+import { verifyToken } from "@/lib/server/auth";
+
+export default async function Home() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("auth")?.value;
+  if (!token) redirect("/login");
+  try {
+    const user = await verifyToken(token);
+    if (user.role === "admin") {
+      redirect("/admin/users");
+    } else {
+      redirect("/dashboard");
+    }
+  } catch {
+    redirect("/login");
+  }
 }

--- a/src/components/logout-button.tsx
+++ b/src/components/logout-button.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+
+export default function LogoutButton() {
+  const router = useRouter();
+
+  const handleLogout = async () => {
+    await fetch("/api/auth/logout", { method: "POST" });
+    router.push("/login");
+  };
+
+  return (
+    <Button variant="ghost" onClick={handleLogout}>
+      Logout
+    </Button>
+  );
+}

--- a/src/layouts/header.tsx
+++ b/src/layouts/header.tsx
@@ -1,15 +1,13 @@
+/* eslint-disable import/order */
 import { headers } from "next/headers";
-
 import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils";
-
+import Breadcrumbs from "@/components/breadcrumbs";
+import LogoutButton from "@/components/logout-button";
 import { Separator } from "@/components/ui/separator";
-
 import SidebarTrigger from "@/layouts/sidebar-trigger";
 import ThemeSwitcher from "@/layouts/theme-switcher";
-
-import Breadcrumbs from "@/components/breadcrumbs";
+import { cn } from "@/lib/utils";
 
 const headerVariants = cva("h-16 flex items-center gap-2", {
   variants: {
@@ -72,8 +70,9 @@ const Header = async ({
         <SidebarTrigger />
         <Separator orientation="vertical" className="me-2" />
         <Breadcrumbs pathname={pathname} />
-        <div className="ms-auto">
+        <div className="ms-auto flex items-center gap-2">
           <ThemeSwitcher />
+          <LogoutButton />
         </div>
       </div>
     </header>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -30,6 +30,16 @@ export async function middleware(request: NextRequest) {
         return unauthorized(request);
       }
     }
+    if (
+      pathname.startsWith("/dashboard") ||
+      pathname.startsWith("/projects") ||
+      pathname.startsWith("/api/projects") ||
+      pathname.startsWith("/api/tasks")
+    ) {
+      if (user.role !== "user") {
+        return unauthorized(request);
+      }
+    }
     return NextResponse.next({ headers });
   } catch {
     return unauthorized(request);


### PR DESCRIPTION
## Summary
- Redirect users based on role and allow admins to manage user accounts
- Let users create projects and tasks while enforcing role-based API and middleware checks
- Add logout button and cascade-delete of users' projects and tasks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6899d0d0bc84832aa3b968357c5507c9